### PR TITLE
[EIP] Security Warning

### DIFF
--- a/EIPS/eip-1001.md
+++ b/EIPS/eip-1001.md
@@ -40,6 +40,10 @@ Where all of the key + value pairs are optional, allowing for maximum flexibilit
 `name` (optional) is a name ofthe private key - e.g. "paper wallet"
 `type` (optional) is the type of key (STRING) - Defaults to ECDSA
 
+### Security Warning
+
+Since private keys are highly sensitive information, it is considerably safer if input (via QR code, keyboard etc.) is handled directly by the target application, rather than going through some IPC mechanism (e.g. the Intent mechanism in Android OS), trusting third-party applications (such as a QR code reader) with the private key. Thus, it is **recommended** to display a security warning, whenever the application receives a private key through IPC messaging, warning the user about the risks associated with using a third-party application to input private keys.
+
 ## Compatibility and Versioning
 Future upgrades that are partially or fully incompatible with this proposal must use a prefix other than `private_key-` that is separated by a dash (`-`) character from whatever follows it, as specified by ERC #831.
 


### PR DESCRIPTION
Recommendation to display a security warning, if users engage in unsafe IPC, e.g. by using a general-purpose QR code reader rather than the integrated one.